### PR TITLE
Minor bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #OpenShift Labs
-
+ 
 This application was designed to manage and deploy OpenShift instances for testing purposes. The OpenShift deployments are not designed to be permanent, but instead to be re-deployed repeatedly. 
 
 The application supports automatic deployment of small and extremely large OpenShift deployments. Deploying HA datastores and activemq servers is also supported. Deploying fully HA environments with HA brokers and an external load balancer is not yet supported.

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -22,7 +22,7 @@ class Lab < ActiveRecord::Base
   end
 
   def get_keystone
-    OpenStack::Connection.create({:username => self.username, :api_key => self.password, :auth_url => self.api_url, :authtenant_name => "admin", :service_type => "identity"})
+    OpenStack::Connection.create({:username => self.username, :api_key => self.password, :auth_url => self.api_url, :authtenant_name => self.auth_tenant, :service_type => "identity"})
   end
 
 private

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,5 @@
 # Set up the global variable $redis with a connection to the redis store
-host = ENV['OPENSHIFT_REDIS_HOST'] || CONFIG[:redis_host] || localhost
+host = ENV['OPENSHIFT_REDIS_HOST'] || CONFIG[:redis_host] || "localhost"
 port = ENV['OPENSHIFT_REDIS_PORT'] || CONFIG[:redis_port] || 6379
 password = ENV['REDIS_PASSWORD'] || CONFIG[:redis_password] || nil
 if password


### PR DESCRIPTION
Getting this in prod for PUT /labs/:id (modifying a lab):

  ActiveRecord::UnknownAttributeError (unknown attribute: utf8):
    app/controllers/labs_controller.rb:33:in `update'

hopefully this fixes it.

Also can't authenticate to openstack with a tenant != admin -> use auth_tenant for this instead of hardcoded "admin".

Also including a change that was introduced downstream 896d8a7 to
avoid potential conflicts in the future, and adding missing quotes
for "localhost" in default redis config.