### PR TITLE
Remove minimum lenght restriction on names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ActiveRecord::Base
   validates :first_name, :last_name, :username, :email, presence: true
   validates :email, uniqueness: true
   validates :email, format: /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i
-  validates :first_name, :last_name, length: {minimum: 3}
 
   before_validation :get_user_details
   before_create :check_admin


### PR DESCRIPTION
We found that the app was returning 422's to some users, who turned out to have 2 characters long surnames.

In some places it's very common to have first/last names that are less than 3 characters long. We're already validating that the fields are present, so no need to restrict its content's length.
