### PR TITLE
Fix brokerName on activemq HA setups

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -484,7 +484,8 @@ private
                   :CONF_NAMED_IP_ADDR => project_details[:named_ip],
                   :CONF_NAMED_HOSTNAME => project_details[:named_hostname],
                   :CONF_DATASTORE_HOSTNAME => project_details[:datastore_replicants].first,
-                  :CONF_ACTIVEMQ_HOSTNAME => project_details[:activemq_replicants].first,
+                  :CONF_ACTIVEMQ_HOSTNAME => self.types.include?('activemq') ? self.fqdn :
+                                             project_details[:activemq_replicants].first,
                   :CONF_BROKER_HOSTNAME => project_details[:broker_hostname],
                   :CONF_NODE_HOSTNAME => project_details[:node_hostname],
                   :CONF_INSTALL_COMPONENTS => self.types.join(","),


### PR DESCRIPTION
On replicated ActiveMQ setups, brokerName in activemq.xml is incorrectly being set to the first replica's hostname on all of the replica systems.

CONF_ACTIVEMQ_HOSTNAME must point to self.fqdn on ActiveMQ hosts so that brokerName is set correctly in activemq.xml.
